### PR TITLE
Add XDG_DATA_DIRS to access libportal

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -36,13 +36,15 @@ apps:
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/gnome-platform/usr/lib/python3/dist-packages
       
 parts:
+
   eog:
+    #after: [ libportal ]
     source: https://gitlab.gnome.org/GNOME/eog.git
     source-type: git
     source-tag: '40.2'
     parse-info: [usr/share/metainfo/eog.appdata.xml]
     plugin: meson
-    meson-parameters: [--prefix=/snap/eog/current/usr, -Dintrospection=true, -Dlibportal=true]
+    meson-parameters: [--prefix=/snap/eog/current/usr, -Dintrospection=true, -Dlibportal=false]
     meson-version: 0.58.1
     organize:
       snap/eog/current/usr: usr
@@ -62,6 +64,8 @@ parts:
       - libjpeg-dev
       - liblcms2-dev
       - zlib1g-dev
+    build-environment:
+      - XDG_DATA_DIRS: $SNAPCRAFT_STAGE/usr/share:/usr/share:$XDG_DATA_DIRS
 
   libraries:
     after: [eog]


### PR DESCRIPTION
## Description

The eog part needed XDG_DATA_DIRS to be able to find the libportal in the platform snap. This is a runtime requirement. The current eog in --stable is broken (runtime only) because of this.

## Type of change

Please check only the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built locally and tested in both focal and jammy vms.

